### PR TITLE
[self] Split content_change into content_change and control_change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-elastic-sheets-project/*
-elastic-sheets-share/*
+elastic-sheets-*/*

--- a/src/frontend/data-models/DataExplorerTemplate.js
+++ b/src/frontend/data-models/DataExplorerTemplate.js
@@ -117,7 +117,7 @@ var DataExplorerTemplate =
          }
       }
    },
-   "trigger": "content_change",
+   "trigger": "control_change",
    "sql_table": {
       "enabled": false,
       "query": "--SHOW TABLES\n--DESCRIBE $$index\n--SELECT * FROM $$index WHERE $$query $$pagination"

--- a/src/frontend/managers/elasticsearchManager.js
+++ b/src/frontend/managers/elasticsearchManager.js
@@ -392,7 +392,9 @@ var ElasticsearchManager = (function(){
       case "config_change":
         return (tableTrigger != "disabled") && (tableTrigger != "manual")
       case "control_change":
-        return (tableTrigger == "control_change")
+        return (tableTrigger == "control_change") || (tableTrigger == "content_change")
+      case "content_change":
+        return (tableTrigger == "content_change")
       default:
         return true
     }
@@ -405,7 +407,8 @@ var ElasticsearchManager = (function(){
     retrieveIndexPatternFields: retrieveIndexPatternFields,
 
     TESTONLY: {
-      convertFieldFilterToSource_: convertFieldFilterToSource_
+      convertFieldFilterToSource_: convertFieldFilterToSource_,
+      isTriggerEnabled_: isTriggerEnabled_
     }
   }
 

--- a/src/frontend/managers/elasticsearchManager.js
+++ b/src/frontend/managers/elasticsearchManager.js
@@ -385,14 +385,14 @@ var ElasticsearchManager = (function(){
   /** Checks whether a requested re-populate is desired */
   function isTriggerEnabled_(tableConfig, trigger) {
     //(copy paste from ElasticsearchService.handleContentUpdates.isTriggerEnabled)
-    var tableTrigger = tableConfig.trigger || "content_change"
+    var tableTrigger = tableConfig.trigger || "control_change"
     switch(trigger) {
       case "manual":
         return (tableTrigger != "disabled")
       case "config_change":
         return (tableTrigger != "disabled") && (tableTrigger != "manual")
-      case "content_change":
-        return (tableTrigger == "content_change")
+      case "control_change":
+        return (tableTrigger == "control_change")
       default:
         return true
     }

--- a/src/frontend/managers/tableListManager.js
+++ b/src/frontend/managers/tableListManager.js
@@ -159,6 +159,9 @@ var TableListManager = (function() {
     // Get tables in need of refresh:
     google.script.run.withSuccessHandler(function(obj) {
       try {
+//TODO: if entries non-empty, check ES and schedule a longeer timeout if not configured
+
+
         Object.entries(obj).map(function(kv) {
           var tableConfig = State_.getEntryByName(kv[0])
           if (tableConfig) {

--- a/src/frontend/managers/tableListManager.js
+++ b/src/frontend/managers/tableListManager.js
@@ -147,6 +147,12 @@ var TableListManager = (function() {
   /** Timer interval */
   var timerInterval_ = 5000 //(ms)
 
+  /** Latched when ES is seen to have been configured */
+  var esAuthConfigured_ = false
+
+  /** Latched first time we log that ES isn't configured */
+  var esAuthConfiguredLog_ = false
+
   /** At desired interval, checks if any tables need refreshing */
   function onTableRefresh_() {
 
@@ -157,26 +163,50 @@ var TableListManager = (function() {
     }
 
     // Get tables in need of refresh:
-    google.script.run.withSuccessHandler(function(obj) {
-      try {
-//TODO: if entries non-empty, check ES and schedule a longeer timeout if not configured
-
-
-        Object.entries(obj).map(function(kv) {
-          var tableConfig = State_.getEntryByName(kv[0])
-          if (tableConfig) {
-            tableConfig = tableConfig.temp ? tableConfig.temp : tableConfig
-            ElasticsearchManager.populateTable(kv[0], tableConfig, kv[1], /*testMode*/false)
-          }
-        })
-      } catch (err) {
-        throw err
-      } finally {
+    var lookForTriggeredTables = function() {
+      google.script.run.withSuccessHandler(function(obj) {
+        try {
+          Object.entries(obj).map(function(kv) {
+            var tableConfig = State_.getEntryByName(kv[0])
+            if (tableConfig) {
+              tableConfig = tableConfig.temp ? tableConfig.temp : tableConfig
+              ElasticsearchManager.populateTable(kv[0], tableConfig, kv[1], /*testMode*/false)
+            }
+          })
+        } catch (err) {
+          throw err
+        } finally {
+          scheduleNextRefresh()
+        }
+      }).withFailureHandler(function(err) {
         scheduleNextRefresh()
-      }
-    }).withFailureHandler(function(err) {
-      scheduleNextRefresh()
-    }).listTriggeredTables()
+      }).listTriggeredTables()
+    }
+
+    if (esAuthConfigured_) {
+      lookForTriggeredTables()
+    } else {
+      // Very simple logic to stop unconfigured ES from stealing triggers
+      //(of course it's still very easy to steal triggers, just not quite as inadvertently)
+      google.script.run.withSuccessHandler(function(obj) {
+        if (obj) ElasticsearchManager.getEsReadiness(obj.es_meta || {},
+          function(esMeta) { // ready
+            esAuthConfigured_ = true //(no longer check until table builder reloaded)
+            lookForTriggeredTables()
+          },
+          function(esMeta) { // not ready
+            if (!esAuthConfiguredLog_) {
+              delete esMeta.password //(avoid leaking to logs if URL is not configured)
+              console.log(`ES not configured [${JSON.stringify(esMeta)}], will keep checking until it is`)
+              esAuthConfiguredLog_ = true
+            }
+            scheduleNextRefresh()
+          }
+        )
+      }).withFailureHandler(function(obj) {
+        console.log("Failed to retrieve ES metadata: [" + JSON.stringify(obj) + "]")
+      }).getElasticsearchMetadata()
+    }
   }
 
   var State_ = (function() {

--- a/src/frontend/view-models/sidebarAppGeneralEditor.js
+++ b/src/frontend/view-models/sidebarAppGeneralEditor.js
@@ -33,6 +33,7 @@ var GeneralEditor = (function(){
     <option value='manual'>Manual</option>
     <option value='config_change'>Config Change</option>
     <option value='control_change'>Control Change</option>
+    <option value='content_change'>Content Change</option>
     </select>
     </div>
 

--- a/src/frontend/view-models/sidebarAppGeneralEditor.js
+++ b/src/frontend/view-models/sidebarAppGeneralEditor.js
@@ -32,7 +32,7 @@ var GeneralEditor = (function(){
     <option value='disabled'>Disabled</option>
     <option value='manual'>Manual</option>
     <option value='config_change'>Config Change</option>
-    <option value='content_change'>Content Change</option>
+    <option value='control_change'>Control Change</option>
     </select>
     </div>
 
@@ -100,7 +100,7 @@ var GeneralEditor = (function(){
   function populate(index, name, json, tableType) {
 
     // Trigger:
-    var trigger = json.trigger || "content_change"
+    var trigger = json.trigger || "control_change"
     $(`#trigger_${tableType}_${index}`).val(trigger)
 
     // Query bar

--- a/src/server/Code.gs
+++ b/src/server/Code.gs
@@ -17,7 +17,7 @@ function onInstall() { return UiService_.onOpen() }
 
 /** Edit trigger */
 function onEdit(e) {
-  return ElasticsearchService_.handleContentUpdates(e.range, /*triggerOverride*/null)
+  return ElasticsearchService_.handleContentUpdates(event, /*triggerOverride*/null)
 }
 
 /** Allows for UI to launch a full screen dialog showing the query that would be launched */
@@ -184,5 +184,6 @@ function buildEsSubTable(subTableCell, configOverride) {
 
 /** Triggers a refresh of the table that is currently "under the cursor" */
 function refreshSelectedTable() {
-  return ElasticsearchService_.handleContentUpdates(SpreadsheetApp.getActiveRange(), "manual")
+  var event = { range: SpreadsheetApp.getActiveRange() }
+  return ElasticsearchService_.handleContentUpdates(event, "manual")
 }

--- a/src/server/Code.gs
+++ b/src/server/Code.gs
@@ -17,7 +17,7 @@ function onInstall() { return UiService_.onOpen() }
 
 /** Edit trigger */
 function onEdit(e) {
-  return ElasticsearchService_.handleContentUpdates(event, /*triggerOverride*/null)
+  return ElasticsearchService_.handleContentUpdates(e, /*triggerOverride*/null)
 }
 
 /** Allows for UI to launch a full screen dialog showing the query that would be launched */

--- a/src/server/models/ElasticsearchMetaModel.gs
+++ b/src/server/models/ElasticsearchMetaModel.gs
@@ -9,6 +9,6 @@ var esMetaModel_ = {
    "header_json": {}, //key, value map
    "client_options_json": {}, //(passed directly to ES client)
    "enabled": true,
-   "query_trigger": "timed_content", //"none", "timed_config", "timed_content"
+   "query_trigger": "timed_control", //"none", "timed_config", "timed_control", "timed_content"
    "query_trigger_interval_s": 5
 }

--- a/src/server/models/ElasticsearchMetaModel.gs
+++ b/src/server/models/ElasticsearchMetaModel.gs
@@ -9,6 +9,6 @@ var esMetaModel_ = {
    "header_json": {}, //key, value map
    "client_options_json": {}, //(passed directly to ES client)
    "enabled": true,
-   "query_trigger": "timed_control", //"none", "timed_config", "timed_control", "timed_content"
+   "query_trigger": "timed_content", //"none", "timed_config", "timed_control", "timed_content"
    "query_trigger_interval_s": 5
 }

--- a/src/server/models/TableModel.gs
+++ b/src/server/models/TableModel.gs
@@ -1,6 +1,6 @@
 /** The default table config - also using to sort-of-document the model */
 var defaultTableConfig_ = {
-  "trigger": "content_change", //OR "disabled", "manual", "config_change", content_change" - later  "timed"
+  "trigger": "control_change", //OR "disabled", "manual", "config_change", control_change" - later  "timed"
   "common": {
 //     "refresh": {
 //        "on_query_change": true,

--- a/src/server/models/TableModel.gs
+++ b/src/server/models/TableModel.gs
@@ -1,6 +1,6 @@
 /** The default table config - also using to sort-of-document the model */
 var defaultTableConfig_ = {
-  "trigger": "control_change", //OR "disabled", "manual", "config_change", control_change" - later  "timed"
+  "trigger": "control_change", //OR "disabled", "manual", "config_change", control_change", "content_change" (timed will be separate param)
   "common": {
 //     "refresh": {
 //        "on_query_change": true,

--- a/src/server/services/ManagementService.gs
+++ b/src/server/services/ManagementService.gs
@@ -165,9 +165,9 @@ var ManagementService_ = (function(){
               trigger = "manual" //nothing can overwrite manual (except "")
               break
             case "config_change": //(everything except data_change overwrites)
-              trigger = ("content_change" == trigger) ? curr : trigger
+              trigger = ("control_change" == trigger) ? curr : trigger
               break
-            default: //("" or "content_change" - always update)
+            default: //("" or "control_change" - always update)
               break
           }
         }

--- a/src/server/services/ManagementService.gs
+++ b/src/server/services/ManagementService.gs
@@ -164,10 +164,15 @@ var ManagementService_ = (function(){
             case "manual":
               trigger = "manual" //nothing can overwrite manual (except "")
               break
-            case "config_change": //(everything except data_change overwrites)
-              trigger = ("control_change" == trigger) ? curr : trigger
+            case "config_change": //(everything except control/content_change overwrites)
+              trigger =
+                (("control_change" == trigger) || ("content_change" == trigger))
+                  ? curr : trigger
               break
-            default: //("" or "control_change" - always update)
+            case "control_change": //(everything except content_change overwrites)
+              trigger = ("content_change" == trigger) ? curr : trigger
+              break
+            default: //("" or "content_change" - always update)
               break
           }
         }

--- a/src/server/services/TableService.gs
+++ b/src/server/services/TableService.gs
@@ -163,8 +163,10 @@ var TableService_ = (function(){
      }
   }
 
-  /** Returns a map of tables intersecting the given range */
-  function findTablesIntersectingRange(range) {
+  /** Returns a map of tables intersecting the given range
+  * if addRange is set to true then inject the range as activeRange
+  */
+  function findTablesIntersectingRange(range, addRange) {
     var ss = SpreadsheetApp.getActive()
     var currRange = ss.getActiveRange()
     var tableMap = ManagementService_.listSavedObjects()
@@ -173,7 +175,10 @@ var TableService_ = (function(){
     Object.keys(namedRangeMap).forEach(function(tableName) {
       var namedRange = namedRangeMap[tableName]
       if (TableRangeUtils_.doRangesIntersect(range, namedRange.getRange())) {
-        retVal[tableName] = tableMap[tableName]
+        retVal[tableName] = TableRangeUtils_.shallowCopy(tableMap[tableName])
+        if (addRange) {
+          retVal[tableName].activeRange = namedRange.getRange()
+        }
       }
     })
     return retVal

--- a/src/server/utils/ElasticsearchRequestUtils.gs
+++ b/src/server/utils/ElasticsearchRequestUtils.gs
@@ -427,7 +427,7 @@ var ElasticsearchRequestUtils_ = (function() {
                     (ii != specialRows.headers) && (ii != specialRows.query_bar) && ((ii + 1) != dataFormatRowSampleOffset))
                 {
                    var offset = activeRange.offset(ii - 1, 0, 1)
-                   dataFormatRowSample.copyTo(offset, {formatOnly:true})
+                   if (!testMode) dataFormatRowSample.copyTo(offset, {formatOnly:true})
                 }
              }
              for (var ii = 1; ii <= 4; ++ii) { // top 4

--- a/src/server/utils/ElasticsearchRequestUtils.gs
+++ b/src/server/utils/ElasticsearchRequestUtils.gs
@@ -9,6 +9,7 @@ var ElasticsearchRequestUtils_ = (function() {
    * { "query": string, "data_size": int, "page": int, <- these are used by the client to build the query
    *    status_offset: { row: int, col: int }, <- passed back post query completion to avoid double calling
    *    page_info_offset: { row: int, col: int } }  <- passed back post query completion to avoid double calling
+   *    query_offset: { row: int, col: int } }  <- passed back post query completion to avoid double calling
    * (page starts at 1)
    */
   function buildTableOutline(tableName, tableConfig, activeRange, statusInfo, testMode) {
@@ -102,6 +103,7 @@ var ElasticsearchRequestUtils_ = (function() {
               queryCells.merge()
               break
         }
+        retVal.query_offset = { row: queryRow, col: 2 }
      }
 
      // Status (if not merged)
@@ -427,7 +429,7 @@ var ElasticsearchRequestUtils_ = (function() {
                     (ii != specialRows.headers) && (ii != specialRows.query_bar) && ((ii + 1) != dataFormatRowSampleOffset))
                 {
                    var offset = activeRange.offset(ii - 1, 0, 1)
-                   if (!testMode) dataFormatRowSample.copyTo(offset, {formatOnly:true})
+                   dataFormatRowSample.copyTo(offset, {formatOnly:true})
                 }
              }
              for (var ii = 1; ii <= 4; ++ii) { // top 4

--- a/test/frontend/managers/testElasticsearchManager.js
+++ b/test/frontend/managers/testElasticsearchManager.js
@@ -2,7 +2,6 @@ var TestElasticsearchManager = (function() {
 
   var testSuiteRoot = "testElasticsearchManager"
 
-  /** Add new aggregation forms to an empty list */
   QUnit.test(`[${testSuiteRoot}] test _source generation`, function(assert) {
     var filterFieldTests = {
       "-,+": { includes: [], excludes: [] },
@@ -35,7 +34,6 @@ var TestElasticsearchManager = (function() {
 
   })
 
-  /** Add new aggregation forms to an empty list */
   QUnit.test(`[${testSuiteRoot}] test trigger check`, function(assert) {
     var options = [
       "disabled", "manual", "config_change", "control_change", "content_change"
@@ -57,6 +55,68 @@ var TestElasticsearchManager = (function() {
       actual.push(actualRow)
     })
     assert.deepEqual(actual, expected, "Trigger matrix")
+  })
+
+  QUnit.test(`[${testSuiteRoot}] test ES readiness check`, function(assert) {
+    var esMeta1 = {} //(missing URL)
+    var ready1 = true
+    ElasticsearchManager.getEsReadiness(esMeta1,
+      function(esMeta) { //ready
+      },
+      function(esMeta) { //not ready
+        assert.deepEqual(esMeta, { enabled: true }, "Empty ES counts as enabled")
+        ready1 = false
+      }
+    )
+    assert.equal(ready1, false, "ES ready 1, no URL")
+
+    var esMeta2 = { enabled: true, auth_type: "password", password: "test" } //(missing URL)
+    var ready2 = true
+    ElasticsearchManager.getEsReadiness(esMeta2,
+      function(esMeta) { //ready
+      },
+      function(esMeta) { //not ready
+        assert.deepEqual(esMeta, esMeta2, "ES meta object passed in to failure")
+        ready2 = false
+      }
+    )
+    assert.equal(ready2, false, "ES ready 2, no URL")
+
+    var esMeta3 = { enabled: true, auth_type: "password", password: "test", url: "test" }
+    var ready3 = false
+    ElasticsearchManager.getEsReadiness(esMeta3,
+      function(esMeta) { //ready
+        assert.deepEqual(esMeta, esMeta3, "ES meta object passed in to success")
+        ready3 = true
+      },
+      function(esMeta) { //not ready
+      }
+    )
+    assert.equal(ready3, true, "ES ready 3")
+
+    var esMeta4 = { auth_type: "password", url: "test" }
+    var ready4 = true
+    ElasticsearchManager.getEsReadiness(esMeta4,
+      function(esMeta) { //ready
+      },
+      function(esMeta) { //not ready
+        ready4 = false
+      }
+    )
+    assert.equal(ready4, true, "ES ready 4")
+
+    var esMeta5 = { enabled: false, auth_type: "password", password: "test", url: "test" }
+    var ready5 = true
+    ElasticsearchManager.getEsReadiness(esMeta5,
+      function(esMeta) { //ready
+      },
+      function(esMeta) { //not ready
+        assert.deepEqual(esMeta, esMeta5, "ES meta object passed in to failure")
+        ready5 = false
+      }
+    )
+    assert.equal(ready5, false, "ES ready 5, disabled")
+
   })
 
 }())

--- a/test/frontend/managers/testElasticsearchManager.js
+++ b/test/frontend/managers/testElasticsearchManager.js
@@ -35,4 +35,28 @@ var TestElasticsearchManager = (function() {
 
   })
 
+  /** Add new aggregation forms to an empty list */
+  QUnit.test(`[${testSuiteRoot}] test trigger check`, function(assert) {
+    var options = [
+      "disabled", "manual", "config_change", "control_change", "content_change"
+    ]
+    var expected = [
+      [ 1, 0, 0, 0, 0],
+      [ 1, 1, 0, 0, 0],
+      [ 1, 1, 1, 0, 0],
+      [ 1, 1, 1, 1, 0],
+      [ 1, 1, 1, 1, 1],
+    ]
+    var actual = []
+    options.forEach(function(ii) {
+      var actualRow = []
+      options.forEach(function(jj) {
+        var config = { trigger: ii }
+        actualRow.push(ElasticsearchManager.TESTONLY.isTriggerEnabled_(config, jj) ? 1 : 0)
+      })
+      actual.push(actualRow)
+    })
+    assert.deepEqual(actual, expected, "Trigger matrix")
+  })
+
 }())

--- a/test/server/services/TestElasticsearchService.gs
+++ b/test/server/services/TestElasticsearchService.gs
@@ -230,6 +230,7 @@
          var expectedDataSize = 10
          var numTestCases = 1
          var testCaseInfoArray = []
+         var queryPosition = { col: 2 , row: 1 }
          if (includeQueryBar) {
             expectedDataSize--
             numTestCases *= Object.keys(queryTestCases).length
@@ -297,6 +298,9 @@
            var retVal = ElasticsearchService_.getElasticsearchMetadata("use_named_range", tableConfig, testMode)
 
            var expectedTableConfig = { data_size: expectedDataSize, page: expectedPage, query: expectedQuery }
+           if (includeQueryBar) {
+              expectedTableConfig.query_offset = queryPosition
+           }
            if (includePagination) {
               expectedTableConfig.page_info_offset = pagePosition
            }

--- a/test/server/services/TestElasticsearchService.gs
+++ b/test/server/services/TestElasticsearchService.gs
@@ -394,6 +394,154 @@
       // - clears rest of data
    }
 
+   /** (PUBLIC) ElasticsearchService.handleContentUpdates */
+   function handleContentUpdates_(testSheet, testResults) {
+
+     // Create management service, with trigger on "manual"
+
+     ManagementService_.deleteManagementService()
+
+     var testConfig = TestService_.Utils.deepCopyJson(baseEsConfig_)
+     testConfig.query_trigger = "none"
+     ElasticsearchService_.configureElasticsearch(testConfig)
+     TableService_.listTableConfigs() //<- adds the default table config
+
+     // Check if the trigger isn't set then insta-exits
+
+     TestService_.Utils.performTest(testResults, "Quick exit if disabled", function() {
+       var retVal = ElasticsearchService_.handleContentUpdates({}, /*triggerOverride*/null)
+       TestService_.Utils.assertEquals(-1, retVal)
+     })
+
+     testConfig.query_trigger = "timed_control"
+     ElasticsearchService_.configureElasticsearch(testConfig)
+
+     // Create 2 tables and then:
+
+     var baseTableConfig = TestService_.Utils.deepCopyJson(defaultTableConfig_)
+     baseTableConfig.common.query.source = "local"
+     baseTableConfig.common.pagination.source = "local"
+     // ie B1 is query, B2 is status, B5 is pagination
+
+     // table1:
+     testSheet.setActiveRange(testSheet.getRange("A1:E5"))
+     TableService_.createTable("testa", TableRangeUtils_.shallowCopy(baseTableConfig))
+
+     // table2:
+     testSheet.setActiveRange(testSheet.getRange("F1:J5"))
+     TableService_.createTable("testb", TableRangeUtils_.shallowCopy(baseTableConfig))
+
+     //(external page)
+     testSheet.getRange("A10").setValue(10)
+
+     TestService_.Utils.performTest(testResults, "(table build worked)", function() {
+       //(get context of UI)
+       var uiInfo = JSON.stringify(TestService_.getTestUiEvents())
+       //(quickly check that worked)
+       var tables = ManagementService_.listSavedObjects()
+       TestService_.Utils.assertEquals(
+         [ ManagementService_.getDefaultKeyName(), "testa", "testb"], Object.keys(tables),
+         uiInfo
+       )
+     })
+
+     // Utils:
+
+     var resetTables = function() {
+       testSheet.getRange("B2").setValue("test_status")
+       testSheet.getRange("B5").setValue(2)
+       ManagementService_.updateTempSavedObject("testa", "testa", null)
+       ManagementService_.setSavedObjectTrigger("testa", "")
+       testSheet.getRange("G2").setValue("test_status")
+       testSheet.getRange("G5").setValue(2)
+       ManagementService_.updateTempSavedObject("testb", "testb", null)
+       ManagementService_.setSavedObjectTrigger("testb", "")
+     }
+
+     var getResults = function(name, rangeA1, statusA1, pageA1) {
+       var newStatus = /(\w+ \w+)/.exec(testSheet.getRange(statusA1).getValue())[1]
+       var newPage = testSheet.getRange(pageA1).getValue()
+       var allValues = JSON.stringify(testSheet.getRange(rangeA1).getValues())
+       var checkResults = ManagementService_.listSavedObjects()
+       return [
+        { p: newPage, s: newStatus, t: checkResults[name].temp_trigger || "" },
+        allValues
+       ]
+     }
+     var noPagination = TestService_.Utils.deepCopyJson(baseTableConfig)
+     noPagination.common.pagination.source = "none"
+
+     // Now check triggers:
+
+    // page of table 1
+     TestService_.Utils.performTest(testResults, "Page changes", function() {
+       resetTables()
+       var changeEvent = { range: testSheet.getRange("B5") }
+
+       var retVal = ElasticsearchService_.handleContentUpdates(changeEvent, /*triggerOverride*/null)
+       TestService_.Utils.assertEquals(1, retVal, "retval (page)")
+       var results = getResults("testa", "A1:E5", "B2", "B5")
+       TestService_.Utils.assertEquals(
+         { p: 2, s: "AWAITING REFRESH", t: "control_change"}, results[0], "page=[" + results[1] + "]"
+       )
+       //(Add a temp object with pagination turned off)
+       resetTables()
+       ManagementService_.updateTempSavedObject("testa", "testa", noPagination)
+
+       var retVal = ElasticsearchService_.handleContentUpdates(changeEvent, /*triggerOverride*/null)
+       TestService_.Utils.assertEquals(0, retVal, "retval (nopage)")
+       var results = getResults("testa", "A1:E5", "B2", "B5")
+       TestService_.Utils.assertEquals(
+         { p: 2, s: "HAND EDITED", t: ""}, results[0], "nopage=[" + results[1] + "]"
+       )
+     })
+
+     // query of table 2 (no pagination, page is formula, page gets changed)
+     TestService_.Utils.performTest(testResults, "Query changes", function() {
+       var tests = [
+         { temp: null, formula: false, expectedPage: 1 },
+         { temp: null, formula: true, expectedPage: 10 },
+         { temp: noPagination, formula: false, expectedPage: 2 }
+       ]
+       tests.forEach(function(testConfig) {
+         resetTables()
+         if (testConfig.temp) {
+           ManagementService_.updateTempSavedObject("testb", "testb", noPagination)
+         }
+         if (testConfig.formula) {
+           testSheet.getRange("G5").setFormula("=A10")
+         }
+
+         var changeEvent = { range: testSheet.getRange("G1") }
+         var retVal = ElasticsearchService_.handleContentUpdates(changeEvent, /*triggerOverride*/null)
+         TestService_.Utils.assertEquals(1, retVal, "check handleContentUpdates return value")
+
+         var resultsB = getResults("testb", "F1:J5", "G2", "G5")
+         TestService_.Utils.assertEquals(
+           { p: testConfig.expectedPage, s: "AWAITING REFRESH", t: "control_change"}, resultsB[0],
+           "in=[" + JSON.stringify(testConfig) + "], tableB=[" + resultsB[1] + "]"
+         )
+       })
+     })
+
+     // content intersecting range across both tables
+     TestService_.Utils.performTest(testResults, "Content intersection", function() {
+       resetTables()
+       var changeEvent = { range: testSheet.getRange("A3:Z3") }
+       var retVal = ElasticsearchService_.handleContentUpdates(changeEvent, /*triggerOverride*/null)
+       TestService_.Utils.assertEquals(0, retVal, "check handleContentUpdates return value")
+
+       var resultsA = getResults("testa", "A1:E5", "B2", "B5")
+       var resultsB = getResults("testb", "F1:J5", "G2", "G5")
+       TestService_.Utils.assertEquals(
+         { p: 2, s: "HAND EDITED", t: ""}, resultsA[0], "tableA=[" + resultsA[1] + "]"
+       )
+       TestService_.Utils.assertEquals(
+         { p: 2, s: "HAND EDITED", t: ""}, resultsB[0], "tableB=[" + resultsB[1] + "]"
+       )
+     })
+   }
+
    ////////////////////////////////////////////////////////
 
    /** A handy base ES config for use in testing */
@@ -428,6 +576,7 @@
 
    return {
      configureElasticsearch_: configureElasticsearch_,
-     getElasticsearchMetadata_: getElasticsearchMetadata_
+     getElasticsearchMetadata_: getElasticsearchMetadata_,
+     handleContentUpdates_: handleContentUpdates_
    }
  }())

--- a/test/server/services/TestManagementService.gs
+++ b/test/server/services/TestManagementService.gs
@@ -1,0 +1,77 @@
+/*
+ * Sort-of-Unit/Sort-of-Integration tests for LookupService.gs
+ */
+ /** Run only the tests for this service */
+function testManagementServiceRunner() {
+  TestService_.testRunner("ManagementService_", /*deleteTestSheets*/true)
+}
+
+var TestManagementService_ = (function(){
+
+  /** The cut down version that comes from the UI */
+  var baseUiEsConfig =  {
+     "url": "test-url",
+     "username": "user",
+     "password": "pass",
+     "auth_type": "password",
+     "password_global": false
+  }
+  /** (PUBLIC) ManagementService_.setSavedObjectTrigger */
+  function setSavedObjectTrigger_(testSheet, testResults) {
+
+    var baseTableConfig = TestService_.Utils.deepCopyJson(defaultTableConfig_)
+
+    TestService_.Utils.performTest(testResults, "trigger_combos", function() {
+
+      // Add a saved object to reason on:
+      var name = "setSavedObjectTrigger_1"
+      ManagementService_.addSavedObject(name, baseTableConfig)
+
+      var triggerStates = [
+        "", "manual", "config_change", "control_change", "content_change"
+      ]
+      var expectedUpdates = [ //row = current trigger state, col = new trigger state
+        [ 1, 1, 1, 1, 1 ],
+        [ 1, 1, 0, 0, 0 ],
+        [ 1, 1, 1, 0, 0 ],
+        [ 1, 1, 1, 1, 0 ],
+        [ 1, 1, 1, 1, 1 ]
+      ] //1 if i change to _new_ trigger state, 0 otherwise (<0 error)
+
+      var actualUpdates = []
+      var actualContext = []
+      triggerStates.forEach(function(curr) {
+        var actualUpdateRow = []
+        triggerStates.forEach(function(newTrigger) {
+          ManagementService_.setSavedObjectTrigger(name, "") //(clears)
+          ManagementService_.setSavedObjectTrigger(name, curr)
+          
+          ManagementService_.setSavedObjectTrigger(name, newTrigger)
+          var checkResults = ManagementService_.listSavedObjects()
+          if (!checkResults.hasOwnProperty(name)) {
+            actualUpdateRow.push(-10)
+            actualContext.push("[" + name + "] not found")
+          } else {
+            var updatedTrigger = checkResults[name].temp_trigger || ""
+            actualContext.push(updatedTrigger)
+            if (updatedTrigger == newTrigger) {
+              actualUpdateRow.push(1)
+            } else if (updatedTrigger == curr) {
+              actualUpdateRow.push(0)
+            } else {
+              actualUpdateRow.push(-1)
+            }
+          }
+        })
+        actualUpdates.push(actualUpdateRow)
+      })
+      TestService_.Utils.assertEquals(
+        expectedUpdates, actualUpdates, JSON.stringify(actualContext)
+      )
+    })
+  }
+
+  return {
+    setSavedObjectTrigger_: setSavedObjectTrigger_
+  }
+}())

--- a/test/server/services/TestUiService.gs
+++ b/test/server/services/TestUiService.gs
@@ -135,7 +135,7 @@ var TestUiService_ = (function(){
         "test_key_client": "test_value_client"
      }, //(passed directly to ES client)
      "enabled": true,
-     "query_trigger": "test-trigger", //"none", "timed_config", "timed_content"
+     "query_trigger": "test-trigger", //"none", "timed_config", "timed_control", "timed_content"
      "query_trigger_interval_s": 10
   }
 


### PR DESCRIPTION
Partly to make it easier to add 2-way sync later, partly because I got annoyed at the table refreshing when I changed a field (plus other minor usability things)

Now control_change only triggers a refresh if the page or query is changed (and also it resets the page number unless it's formula driven)

Also the sidebar won't accept triggers until ES is configured, so in a multi-user env where a password hasn't been set for one of the users you won't get weird errors