### PR TITLE
[#14] Allow field type override

### DIFF
--- a/src/frontend/view-models/sidebarAppAggregationForm.js
+++ b/src/frontend/view-models/sidebarAppAggregationForm.js
@@ -122,7 +122,7 @@ var AggregationForm = (function(){
     <div class="input-group-addon for-shorter-text">
     <span class="input-group-text">Fields</span>
     </div>
-    <input type="text" class="form-control" placeholder="[+-]glob (** crosses .s) or /regex/" value="${json.field_filter || ''}" id="field_filter_${elementIdSuffix}">
+    <input type="text" class="form-control" placeholder="[+-]glob or /regex/" value="${json.field_filter || ''}" id="field_filter_${elementIdSuffix}">
     </div>
 
     <div class="input-group">

--- a/src/frontend/view-models/sidebarAppAggregationForm.js
+++ b/src/frontend/view-models/sidebarAppAggregationForm.js
@@ -23,7 +23,10 @@ var AggregationForm = (function(){
     var helpHidden = helpUrl ? "" : "hidden"
 
     var maybeCurrentLocation = ""
-    if (json.location && ("automatic" != json.location) && ("disabled" != json.location)) {
+    if (json.location &&
+      ("automatic" != json.location) && ("disabled" != json.location) && ("__root__" != json.location)
+    )
+      {
       maybeCurrentLocation =
         `<option value="${json.location}" selected>Bucket: ${json.location}</option>`
     }
@@ -128,6 +131,7 @@ var AggregationForm = (function(){
     </div>
     <select class="form-control for-shorter-text" id="location_${elementIdSuffix}">
     <option value="automatic">Automatic</option>
+    <option value="__root__" ${("__root__" == json.location) ? "selected" : ""}>Root</option>
     <option value="disabled" ${("disabled" == json.location) ? "selected" : ""}>Disabled</option>
     ${maybeCurrentLocation}
     </select>
@@ -332,12 +336,17 @@ var AggregationForm = (function(){
       AutocompletionManager.aggregationOutputCompleter(TableManager.getTableId(index), [ "buckets" ])
         .getCompletions(null, null, null, null, function(unused, bucketList) {
           $(`#location_${elementIdSuffix}`).empty()
-          $(`#location_${elementIdSuffix}`).append(`<option value="automatic">Automatic</option>`)
-          $(`#location_${elementIdSuffix}`).append(`<option value="disabled">Disabled</option>`)
-          bucketList.forEach(function(bucketMeta) {
-            var name = bucketMeta.value
-            $(`#location_${elementIdSuffix}`).append(`<option value="${name}">Bucket: ${name}</option>`)
-          })
+          var defaultElements = [
+            `<option value="automatic">Automatic</option>`,
+            `<option value="disabled">Disabled</option>`,
+            `<option value="__root__">Root</option>`
+          ]
+          $(`#location_${elementIdSuffix}`).append(
+            defaultElements.concat(bucketList.map(function(bucketMeta) {
+              var name = bucketMeta.value
+              return `<option value="${name}">Bucket: ${name}</option>`
+            }))
+          )
           $(`#location_${elementIdSuffix}`).val(currLocationVal).change()
         })
     })
@@ -396,6 +405,7 @@ function getAggFormNameMap_(parentJson, indexExclude, typeExclude) {
       }
     })
   })
+  retVal["__root__"] = true
   return retVal
 }
 

--- a/src/frontend/view-models/sidebarAppAggregationForm.js
+++ b/src/frontend/view-models/sidebarAppAggregationForm.js
@@ -22,6 +22,12 @@ var AggregationForm = (function(){
     var helpHref = helpUrl ? `href='${helpUrl.url__}'` : ""
     var helpHidden = helpUrl ? "" : "hidden"
 
+    var maybeCurrentLocation = ""
+    if (json.location && ("automatic" != json.location) && ("disabled" != json.location)) {
+      maybeCurrentLocation =
+        `<option value="${json.location}" selected>Bucket: ${json.location}</option>`
+    }
+
     var aggregationTypeTemplate = isMapReduce ?
     `
     <div class="input-group">
@@ -120,10 +126,10 @@ var AggregationForm = (function(){
     <div class="input-group-addon for-shorter-text">
     <span class="input-group-text">Location</span>
     </div>
-    <select class="form-control for-shorter-text" value="${json.location || 'automatic'}" id="location_${elementIdSuffix}">
+    <select class="form-control for-shorter-text" id="location_${elementIdSuffix}">
     <option value="automatic">Automatic</option>
-    <option value="disabled">Disabled</option>
-    <!-- TODO fill with other names -->
+    <option value="disabled" ${("disabled" == json.location) ? "selected" : ""}>Disabled</option>
+    ${maybeCurrentLocation}
     </select>
     </div>
     </div>
@@ -318,6 +324,22 @@ var AggregationForm = (function(){
         var currJsonForm = getCurrAggFormJson_($(`#form_${elementIdSuffix}`), parentContainerId, aggregationType, currJson)
         currJsonForm.location = thisValue
       })
+    })
+
+    // Whenever we change the state of the advanced, reload the
+    $(`#collapse1_${elementIdSuffix}`).on('shown.bs.collapse', function () {
+      var currLocationVal = $(`#location_${elementIdSuffix}`).val()
+      AutocompletionManager.aggregationOutputCompleter(TableManager.getTableId(index), [ "buckets" ])
+        .getCompletions(null, null, null, null, function(unused, bucketList) {
+          $(`#location_${elementIdSuffix}`).empty()
+          $(`#location_${elementIdSuffix}`).append(`<option value="automatic">Automatic</option>`)
+          $(`#location_${elementIdSuffix}`).append(`<option value="disabled">Disabled</option>`)
+          bucketList.forEach(function(bucketMeta) {
+            var name = bucketMeta.value
+            $(`#location_${elementIdSuffix}`).append(`<option value="${name}">Bucket: ${name}</option>`)
+          })
+          $(`#location_${elementIdSuffix}`).val(currLocationVal).change()
+        })
     })
   })
 }

--- a/src/frontend/view-models/sidebarAppTableForm.js
+++ b/src/frontend/view-models/sidebarAppTableForm.js
@@ -226,7 +226,7 @@ var TableForm = (function() {
           }
         }
         if (typeToActivate != "") {
-          $(`#type_${index}`).val(typeToActivate)
+          $(`#type_${index}`).val(typeToActivate).change()
           onTableSelection(typeToActivate)
         }
       }

--- a/src/server/utils/ElasticsearchRequestUtils.gs
+++ b/src/server/utils/ElasticsearchRequestUtils.gs
@@ -329,6 +329,7 @@ var ElasticsearchRequestUtils_ = (function() {
      var postBody = JSON.parse(queryString)
      postBody.size = 0 //(never have any interest in returning docs)
      var aggregationsLocation = getOrPutJsonField(postBody, 'aggregations')
+     elementsByName["__root__"] = postBody
 
      var insertElementsFrom = function(listName, nestEveryTime, noDupCheck) {
         var configArray = aggTable[listName] || []

--- a/src/server/utils/ElasticsearchRequestUtils.gs
+++ b/src/server/utils/ElasticsearchRequestUtils.gs
@@ -361,8 +361,14 @@ var ElasticsearchRequestUtils_ = (function() {
               elementsByName[el.name] = configEl
               if (!el.location || ("automatic" == el.location)) {
                  aggregationsLocation[el.name] = configEl
+                 var filterFieldsStr = (el.field_filter || "").trim()
+                 var colIgnored = (('-' == filterFieldsStr) || ('-*' == filterFieldsStr))
                  if (nestEveryTime) {
-                    aggregationsLocation = getOrPutJsonField(configEl, 'aggregations')
+                    var newAggregationInsertPoint = getOrPutJsonField(configEl, 'aggregations')
+                      //(^just make sure it's present in case we explicitly specify a sub-agg)
+                    if (!colIgnored) {
+                      aggregationsLocation =newAggregationInsertPoint
+                    }
                  }
               } else { // (we'll stash it and sort it out later)
                  var storedEl = {}

--- a/src/server/utils/ElasticsearchResponseUtils.gs
+++ b/src/server/utils/ElasticsearchResponseUtils.gs
@@ -63,7 +63,7 @@ var ElasticsearchResponseUtils_ = (function() {
         tableEls.filter(function(el) { return el.name }).forEach(function(tableEl) {
           var filterFieldsStr = (tableEl.field_filter || "").trim()
           tableColsMap[tableEl.name] = buildFilterFieldRegex_(filterFieldsStr.split(","))
-          if (('-' == filterFieldsStr) || ('-**' == filterFieldsStr)) {
+          if (('-' == filterFieldsStr) || ('-*' == filterFieldsStr)) {
             colsToIgnoreMap[tableEl.name] = true
           }
           if ('buckets' == tableType) {

--- a/test/server/utils/TestElasticsearchRequestUtils.gs
+++ b/test/server/utils/TestElasticsearchRequestUtils.gs
@@ -30,10 +30,13 @@ var TestElasticsearchRequestUtils_ = (function() {
 
            { "name": "n1", "agg_type": "t1", "config": { "ck1": "cv1" }, "location": "automatic" },
            { "name": "n2", "agg_type": "t2", "location": "n3" },
-           { "name": "n3", "agg_type": "t3", "config": { "ck3": "cv3" } }
+           { "name": "n3", "agg_type": "t3", "config": { "ck3": "cv3" } },
+           { "name": "in1", "agg_type": "it1", "config": { "ik1": "iv1" }, "field_filter": "-" }, //(won't be used in automatic location)
          ],
          "metrics": [
-           { "name": "n4", "agg_type": "t4", "config": { "ck4": "cv4" } },
+           { "name": "in2", "agg_type": "it2", "config": { "ik2": "iv2" }, "location": "in1" },
+
+           { "name": "n4", "agg_type": "t4", "config": { "ck4": "cv4" }, "location": "automatic" },
            { "name": "n5", "agg_type": "__map_reduce__", "config": { "ck5": "cv5" }, "location": "n2" },
 
            { "name": "testname", "agg_type": "testtype", "location": "disabled" } //(skip, disabled)
@@ -91,6 +94,18 @@ var TestElasticsearchRequestUtils_ = (function() {
                "aggregations": {
                   "n3": {
                      "aggregations": {
+                       "in1": {
+                         "aggregations": {
+                           "in2": {
+                              "it2": {
+                                 "ik2": "iv2"
+                              }
+                           },
+                         },
+                         "it1": {
+                           "ik1": "iv1"
+                         }
+                       },
                         "n2": {
                            "aggregations": {
                               "n5": {


### PR DESCRIPTION
Fixes #14

[x] test that it actually works in practice (see Kibana example)

^ confirmed last night (it's a bit clunky because once you have created the sub-aggregations to use as siblings, with `field_filter: "-"` then `automatic` location will still try to use the sub-aggregation .... what _should_ happen is that it ignores such aggs unless explicitly specified

Actually let's fix that before merging, should be very straightforward